### PR TITLE
Updated deprecated `include`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: pythonz.yml
-- include: python.yml
+- import_tasks: pythonz.yml
+- import_tasks: python.yml


### PR DESCRIPTION
Replace deprecated include statement to import_tasks ( required for [#106 of the website repo](https://github.com/pyslackers/website/issues/106) )